### PR TITLE
Feat (#15): Sports Section Component

### DIFF
--- a/src/components/section/SportsSection.tsx
+++ b/src/components/section/SportsSection.tsx
@@ -1,0 +1,98 @@
+'use client';
+import Article from '@/components/ui/Article';
+import SportsWinnersContainer from '@/components/ui/SportsWinnersContainer';
+import React, { useMemo } from 'react';
+import sportsArticleData from '@/data/sportsArticleData.json';
+import sportsWinnersData from '@/data/sportsWinnersData.json';
+import { transformSportsData } from '@/utils/transformSportsData';
+
+const COLORS = ['blue', 'green', 'pink', 'white'];
+
+const getValidColors = (bgColor: string, borderColor?: string) => {
+  return COLORS.filter((color) => {
+    if (color === bgColor) return false;
+    if (
+      (bgColor === 'green' && color === 'white') ||
+      (bgColor === 'white' && color === 'green')
+    )
+      return false;
+    if (borderColor && color === borderColor) return false;
+    if (
+      (borderColor === 'green' && color === 'white') ||
+      (borderColor === 'white' && color === 'green')
+    )
+      return false;
+    return true;
+  });
+};
+
+const calculateColorScheme = (seed: number) => {
+  const bgColor = COLORS[seed % COLORS.length];
+  const validColors = getValidColors(bgColor);
+  const borderColorIndex = seed % validColors.length;
+  const borderColor = validColors[borderColorIndex];
+  const validTextColors = getValidColors(bgColor);
+  const textColorIndex = (seed + 1) % validTextColors.length;
+  const textColor = validTextColors[textColorIndex];
+  const headerColorIndex = (seed + 2) % validTextColors.length;
+  const headerColor = validTextColors[headerColorIndex];
+  const validButtonColors = getValidColors(bgColor, borderColor);
+  const buttonTextColor =
+    validButtonColors[(seed + 3) % validButtonColors.length];
+  return {
+    bgColor,
+    borderColor,
+    textColor,
+    headerColor,
+    buttonTextColor,
+  };
+};
+
+const data = transformSportsData(sportsWinnersData, sportsArticleData);
+
+export default function Test() {
+  const colorSchemes = useMemo(() => {
+    return data.map((_, index) => ({
+      articleColors: calculateColorScheme(index),
+      sportsWinnerColors: calculateColorScheme(index + 2),
+    }));
+  }, []);
+
+  return (
+    <div className="w-full">
+      {data.map((event, index) => {
+        const { articleColors, sportsWinnerColors } = colorSchemes[index];
+
+        return (
+          <div key={index} className="flex min-h-[25vh]">
+            <div
+              className={`w-3/5 px-4 py-10 flex justify-center items-center bg-${articleColors.bgColor}`}
+            >
+              <Article
+                imageUrl={event.articleImage}
+                title={event.articleTitle}
+                content={event.articleBody}
+                url={event.articleUrl}
+                borderColor={articleColors.borderColor}
+                headerColor={articleColors.headerColor}
+                textColor={articleColors.textColor}
+                buttonTextColor={articleColors.buttonTextColor}
+              />
+            </div>
+            <div
+              className={`w-2/5 p-4 flex justify-center items-center bg-${sportsWinnerColors.bgColor}`}
+            >
+              <SportsWinnersContainer
+                game_title={event.game_title}
+                winners={event.winners}
+                borderColor={sportsWinnerColors.borderColor}
+                textColor={sportsWinnerColors.textColor}
+                titleTextColor={sportsWinnerColors.buttonTextColor}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ui/Article.tsx
+++ b/src/components/ui/Article.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import Image from 'next/image';
 import ReadMoreButton from './ReadMoreButton';
 import { cva, type VariantProps } from 'class-variance-authority';
@@ -45,6 +46,7 @@ interface ArticleProps
   headerColor: 'blue' | 'green' | 'pink' | 'white';
   textColor: 'blue' | 'green' | 'pink' | 'white';
   buttonTextColor: 'blue' | 'green' | 'pink' | 'white';
+  url: string;
 }
 
 export default function Component({
@@ -55,6 +57,7 @@ export default function Component({
   headerColor,
   textColor,
   buttonTextColor,
+  url,
 }: ArticleProps) {
   return (
     <div
@@ -88,7 +91,10 @@ export default function Component({
           >
             {title}
           </h2>
-          <p className={`${textStyles({ textColor, size: 'content' })}`}>
+          <p
+            className={`${textStyles({ textColor, size: 'content' })} 
+            line-clamp-5 overflow-hidden`}
+          >
             {content}
           </p>
         </div>
@@ -97,6 +103,7 @@ export default function Component({
             bgColor={borderColor}
             textColor={buttonTextColor}
             size="responsive"
+            url={url}
           />
         </div>
       </div>

--- a/src/components/ui/ReadMoreButton.tsx
+++ b/src/components/ui/ReadMoreButton.tsx
@@ -32,13 +32,26 @@ const readMoreButtonStyles = cva(
   }
 );
 
-const ReadMoreButton: FC<VariantProps<typeof readMoreButtonStyles>> = ({
+interface ReadMoreButtonProps
+  extends VariantProps<typeof readMoreButtonStyles> {
+  url: string;
+}
+
+const ReadMoreButton: FC<ReadMoreButtonProps> = ({
   bgColor,
   textColor,
   size,
+  url,
 }) => {
+  const handleClick = () => {
+    window.open(`${url}`, '_blank', 'noopener,noreferrer');
+  };
+
   return (
-    <button className={readMoreButtonStyles({ bgColor, textColor, size })}>
+    <button
+      className={readMoreButtonStyles({ bgColor, textColor, size })}
+      onClick={handleClick}
+    >
       <span className="whitespace-nowrap">
         Read More {'>'}
         {'>'}

--- a/src/components/ui/SportsWinnersContainer.tsx
+++ b/src/components/ui/SportsWinnersContainer.tsx
@@ -1,114 +1,150 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import { FC } from 'react';
 
-//Border & Text Colors
+// Border Styles
 const borderTextStyles = cva(['font-chakra-petch'], {
   variants: {
-    color: {
-      blueBlue: 'border-blue text-blue',
-      blueWhite: 'border-blue text-white',
-      greenBlue: 'border-green text-blue',
-      greenPink: 'border-green text-pink',
-      greenWhite: 'border-green text-white',
-      pinkGreen: 'border-pink text-green',
-      pinkWhite: 'border-pink text-white',
-      pinkBlue: 'border-pink text-blue',
-      whiteBlue: 'border-white text-blue',
-      whitePink: 'border-white text-pink',
-      whiteWhite: 'border-white text-white',
+    borderColor: {
+      green: 'border-green',
+      blue: 'border-blue',
+      white: 'border-white',
+      pink: 'border-pink',
+    },
+    textColor: {
+      green: 'text-green',
+      blue: 'text-blue',
+      white: 'text-white',
+      pink: 'text-pink',
     },
   },
   defaultVariants: {
-    color: 'blueBlue',
+    borderColor: 'blue',
+    textColor: 'blue',
   },
 });
 
-//Title Bakcground & Title Color
+// Title Text Color
 const titleStyles = cva(['font-chakra-petch'], {
   variants: {
-    titleColor: {
-      blueGreen: 'bg-blue text-green',
-      pinkGreen: 'bg-pink text-green',
-      blueWhite: 'bg-blue text-white',
-      pinkWhite: 'bg-pink text-white',
-      pinkBlue: 'bg-pink text-blue',
-      greenBlue: 'bg-green text-blue',
-      greenPink: 'bg-green text-pink',
-      whiteBlue: 'bg-white text-blue',
-      whitePink: 'bg-white text-pink',
+    titleTextColor: {
+      green: 'text-green',
+      blue: 'text-blue',
+      white: 'text-white',
+      pink: 'text-pink',
     },
   },
   defaultVariants: {
-    titleColor: 'blueGreen',
+    titleTextColor: 'blue',
   },
 });
 
-// Define types for color and titleColor props using VariantProps
-type BorderTextColorVariants = VariantProps<typeof borderTextStyles>;
-type TitleColorVariants = VariantProps<typeof titleStyles>;
+type BorderColorVariants = VariantProps<typeof borderTextStyles>['borderColor'];
+type TextColorVariants = VariantProps<typeof borderTextStyles>['textColor'];
+type TitleTextColorVariants = VariantProps<
+  typeof titleStyles
+>['titleTextColor'];
 
-interface Winners {
-  id: number;
+interface Winner {
+  place: string;
+  name: string;
+}
+
+interface SportsWinnerContainerProps {
   game_title: string;
-  first_place_name: string;
-  second_place_name: string;
-  third_place_name: string;
-  color: BorderTextColorVariants['color'];
-  titleColor: TitleColorVariants['titleColor'];
+  winners: Winner[];
+  borderColor: BorderColorVariants;
+  textColor: TextColorVariants;
+  titleTextColor: TitleTextColorVariants;
 }
 
-//Allows winnersArray prop to use color & titleColor
-interface SportsWinnersContainerProps {
-  winnersArray: Winners[];
-}
-
-const SportsWinnersContainer: FC<SportsWinnersContainerProps> = ({
-  winnersArray,
+const SportsWinnerContainer: FC<SportsWinnerContainerProps> = ({
+  game_title,
+  winners,
+  borderColor,
+  textColor,
+  titleTextColor,
 }) => {
+  const renderWinners = () => {
+    const hasVariants = winners.some(
+      (winner) =>
+        winner.place.includes("Women's") ||
+        winner.place.includes("Men's") ||
+        winner.place.includes('Doubles') ||
+        winner.place.includes('Singles')
+    );
+
+    if (hasVariants) {
+      const groupedWinners = winners.reduce<{ [key: string]: Winner[] }>(
+        (acc, winner) => {
+          let groupKey = 'Singles';
+
+          if (winner.place.includes("Women's")) {
+            groupKey = "Women's";
+          } else if (winner.place.includes("Men's")) {
+            groupKey = "Men's";
+          } else if (winner.place.includes('Doubles')) {
+            groupKey = 'Doubles';
+          }
+
+          if (!acc[groupKey]) {
+            acc[groupKey] = [];
+          }
+          acc[groupKey].push(winner);
+          return acc;
+        },
+        {}
+      );
+
+      return (
+        <div className="flex flex-col sm:flex-row gap-4 sm:gap-8">
+          {Object.entries(groupedWinners).map(([groupName, groupWinners]) => (
+            <div key={groupName} className="flex-1">
+              <p className={`font-bold mb-2`}>{groupName}</p>
+              {groupWinners.map((winner, index) => (
+                <div key={index} className="mb-2">
+                  <p>{winner.place.split(' ')[1]} Place</p>
+                  <p>{winner.name}</p>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex flex-col gap-4">
+        {winners.map((winner, index) => (
+          <div key={index}>
+            <p>{winner.place} Place</p>
+            <p>{winner.name}</p>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
   return (
     <div
-      className={`flex flex-col gap-4 max-w-lg min-w-sm text-xl m-auto p-6 `}
+      className={`${borderTextStyles({
+        borderColor,
+        textColor,
+      })} border-4 px-4 sm:px-8 pb-4 flex flex-col gap-4 text-center text-xl font-medium rounded-sm shadow-sm`}
     >
-      {winnersArray.map(
-        ({
-          id,
-          game_title,
-          first_place_name,
-          second_place_name,
-          third_place_name,
-          color,
-          titleColor,
-        }) => {
-          return (
-            <div
-              key={id}
-              className={`${borderTextStyles({ color })} border-4 px-12 pb-4 flex flex-col gap-4 text-center text-xl font-medium rounded-sm shadow-sm`}
-            >
-              <div>
-                <h1
-                  className={`!text-3xl py-2 !font-semibold ${titleStyles({ titleColor })}`}
-                >
-                  {game_title}
-                </h1>
-              </div>
-              <div>
-                <p>First Place</p>
-                <p>{first_place_name}</p>
-              </div>
-              <div>
-                <p>Second Place</p>
-                <p>{second_place_name}</p>
-              </div>
-              <div>
-                <p>Third Place</p>
-                <p>{third_place_name}</p>
-              </div>
-            </div>
-          );
-        }
-      )}
+      <div>
+        <h1
+          className={`!text-3xl py-2 px-3 !font-semibold bg-${borderColor} ${titleStyles(
+            {
+              titleTextColor,
+            }
+          )}`}
+        >
+          {game_title}
+        </h1>
+      </div>
+      {renderWinners()}
     </div>
   );
 };
 
-export default SportsWinnersContainer;
+export default SportsWinnerContainer;

--- a/src/data/sportsArticleData.json
+++ b/src/data/sportsArticleData.json
@@ -1,0 +1,140 @@
+[
+  {
+    "title": "Palarong Atenista ‘24 revives cheerdance; SON Panthers clinch gold",
+    "body": "With the comeback of the competition following an 8-year hiatus since 2016, the School of Nursing (SON) Panthers were hailed as this year’s Palarong Atenista ‘24 cheerdance champions.",
+    "url": "https://atenews.ph/palarong-atenista-24-revives-cheerdance-son-panthers-clinch-gold",
+    "image": ""
+  },
+  {
+    "title": "SS Dragons nab men’s scrabble champ title vs ACC Griffins",
+    "body": "Beating last year’s champion, the Social Science (SS) Dragons brought home the gold medal over the Accountancy (ACC) Griffins through a 2-0 win in the Palarong Atenista 2024 Men’s Scrabble tournament.",
+    "url": "https://atenews.ph/palarong-atenista-24-ss-dragons-nab-mens-scrabble-champ-title-vs-acc-griffins",
+    "image": ""
+  },
+  {
+    "title": "ACC Griffins keep crown in women’s scrabble",
+    "body": "With a 2-0 win, the Accountancy (ACC) Griffins secured a back-to-back championship title in the Palarong Atenista 2024 Women’s Scrabble tournament.",
+    "url": "https://atenews.ph/palarong-atenista-24-acc-griffins-keep-crown-in-womens-scrabble",
+    "image": ""
+  },
+  {
+    "title": "ACC Griffin sweeps chess women’s tourney, defends champ title 2-1",
+    "body": "Remaining undefeated throughout the competition, Accountancy (ACC) Griffins’ Mel Glamoura Olanda gave her cluster a back-to-back gold after triumphing against Natural Sciences and Mathematics (NSM) Falcons’ Aess Anndee Maquiling in this year’s Palarong Atenista. ",
+    "url": "https://atenews.ph/palarong-atenista-24-acc-griffins-sweeps-chess-womens-tourney-defends-champ-title-2-1",
+    "image": ""
+  },
+  {
+    "title": "SEA Tigers snatch gold from undefeated ACC Griffins in chess men’s compe",
+    "body": "Clawing his way in the championship match, the School of Engineering and Architecture Tigers’ Francis Liane Francisco beat undefeated Accountancy Griffins’ Ray Abie Karfael Campaña in a 2-1 finals escape.",
+    "url": "https://atenews.ph/palarong-atenista-24-sea-tigers-snatches-gold-from-undefeated-acc-griffins-in-chess-mens-compe",
+    "image": ""
+  },
+  {
+    "title": "SS defends champ title in men’s badminton doubles, SEA triumphs in singles category",
+    "body": "The Social Sciences (SS) Dragons secured the gold podium for a second time around in the badminton doubles category, while the School of Engineering and Architecture (SEA) Tigers emerged victorious in the singles category during the recently concluded Palarong Atenista 2024 men’s badminton tournament.",
+    "url": "https://atenews.ph/palarong-atenista-24-ss-defends-champ-title-in-mens-badminton-doubles-sea-triumphs-in-singles-category",
+    "image": ""
+  },
+  {
+    "title": "SON bag gold in women’s badminton tourney",
+    "body": "The Social Sciences (SS) Dragons claimed the championship title in the badminton singles category, while the School of Nursing (SON) Panthers clinched victory in the doubles category of the Palarong Atenista 2024 women’s badminton tournament",
+    "url": "https://atenews.ph/palarong-atenista-24-ss-son-bags-gold-in-womens-badminton-tourney",
+    "image": ""
+  },
+  {
+    "title": "SS hails in women’s singles table tennis tourney, NSM goes back-to-back in doubles",
+    "body": "The Social Science (SS) Dragons escaped a dogfight against the Accountancy (ACC) Griffins in the 2024 Palarong Atenista women’s Table Tennis singles championship, with the Natural Sciences and Mathematics (NSM) Falcons cruised against opponents to go back-to back in the women’s doubles.",
+    "url": "https://atenews.ph/palarong-atenista-24-ss-hails-in-womens-singles-table-tennis-tourney-nsm-goes-back-to-back-in-doubles",
+    "image": ""
+  },
+  {
+    "title": "BM Vipers, ACC Griffins top men’s table tennis",
+    "body": "The Accountancy (ACC) Griffins secured the championship title in the Table Tennis Men’s singles category, while the Business and Management (B&M) Vipers seized gold in the doubles category after a tight match against the School of Engineering and Architecture (SEA) Tigers.",
+    "url": "https://atenews.ph/palarong-atenista-24-bm-vipers-acc-griffins-tops-mens-table-tennis",
+    "image": ""
+  },
+  {
+    "title": "SON Panthers secure gold in darts women’s category",
+    "body": "The School of Nursing (SON) Panther secured the championship medal, besting the Humanities and Letters (HUMLET) Wolf in a best-of-three showdown, scoring 2-1.",
+    "url": "https://atenews.ph/palarong-atenista-24-son-panthers-secure-gold-in-darts-womens-category",
+    "image": ""
+  },
+  {
+    "title": "SEA Tigers climb to victory in men’s darts game",
+    "body": "The School of Engineering and Architecture (SEA) Tigers dominated the game and bagged the champion title for the 501 Darts Men Category in this year’s Palarong Atenista ‘24.",
+    "url": "https://atenews.ph/palarong-atenista-24-sea-tigers-climb-to-victory-in-mens-darts-game",
+    "image": ""
+  },
+  {
+    "title": "SON, SEA pioneer champs in pool game debut",
+    "body": "In a notable first for this year’s Palarong Atenista, the School of Nursing (SON) Panthers and School of Engineering and Architecture (SEA) Tigers emerged victorious in the newly added billiards competition in this year’s Palarong Atenista. ",
+    "url": "https://atenews.ph/palarong-atenista-24-son-sea-pioneer-champs-in-pool-game-debut",
+    "image": ""
+  },
+  {
+    "title": "SEA Tigers dump NSM Falcons in football mixed, score back-to-back champ title 2-0",
+    "body": "The School of Engineering and Architecture (SEA) Tigers celebrated a triumphant victory as they led the football match against the Natural Sciences and Mathematics (NSM) Falcons, securing a 2-0 win to claim the championship title for the second consecutive year. ",
+    "url": "https://atenews.ph/palarong-atenista-24-sea-tigers-dump-nsm-falcons-in-football-mixed-score-back-to-back-champ-title-2-0",
+    "image": ""
+  },
+  {
+    "title": "SEA Tigers reclaim MLBB champ title, wipe ACC Griffins 3-0",
+    "body": "Marking a successful return after their 2022 triumph and their failure to advance to last year’s finals, the School of Engineering and Architecture (SEA) Tigers secured a 3-0 victory over the Accountancy (ACC) Griffins in the grand finals of the Palarong Atenista 2024 Mobile Legends: Bang Bang (MLBB) series.",
+    "url": "https://atenews.ph/palarong-atenista-24-sea-tigers-reclaim-mlbb-champ-title-wipe-acc-griffins-3-0",
+    "image": ""
+  },
+  {
+    "title": "SEA Tigers clinch two-peat championship in DOTA 2",
+    "body": "The School of Engineering and Architecture (SEA) Tigers kept their reign as victors over the Computer Studies (CS) Chameleons in a best-of-five DOTA 2 championships during the Palarong Atenista 2024, 3-1.",
+    "url": "https://atenews.ph/palarong-atenista-24-sea-tigers-clinch-two-peat-championship-in-dota-2",
+    "image": ""
+  },
+  {
+    "title": "B&M Vipers topple CS Chammies, regain top spot in Valorant tourney",
+    "body": "After falling short in last year’s Palarong Atenista Valorant Grand Finals, Business and Management (B&M) Vipers asserted their dominance over the defending champions Computer Studies (CS) Chameleons, 3-0, in what seemed like a rematch of last year’s finals round.",
+    "url": "https://atenews.ph/palarong-atenista-24-bm-vipers-topple-cs-chammies-regain-top-spot-in-valorant-tourney",
+    "image": ""
+  },
+  {
+    "title": "SS Dragons dethrones two-peat men’s vball champ B&M vipers, bring home first gold in history",
+    "body": "Dominating their way in the championship match by winning the first 3 sets, the Social Sciences (SS) Dragons claimed their first-ever podium and gold against the two-time champion Business and Management (BM) Vipers in the Palarong Atenista 2024 volleyball finals, securing a 3-0 victory.",
+    "url": "https://atenews.ph/palarong-atenista-24-ss-dragons-dethrones-two-peat-mens-vball-champ-bm-vipers-bring-home-first-gold-in-history",
+    "image": ""
+  },
+  {
+    "title": "SON Panthers win back champ title in women’s vball tourney after two years",
+    "body": "Coming back to the golden podium after their 2022 title, the School of Nursing (SON) Panthers dominated the court of women’s volleyball in the Palarong Atenista ‘24 over the Humanities and Letters (HUMLET) Wolves, 3-0.",
+    "url": "https://atenews.ph/palarong-atenista-24-son-panthers-win-back-champ-title-in-womens-vball-tourney-after-two-years",
+    "image": ""
+  },
+  {
+    "title": "B&M Vipers ousts SEA Tigers in bid for gold in men’s bball, slithers back to victory",
+    "body": "Fresh from last year’s silver, the Business and Management (B&M) Vipers clinched gold in this year’s classic Men’s 5×5 Basketball, declawing the School of Engineering and Architecture (SEA) Tigers, 79-69.",
+    "url": "https://atenews.ph/palarong-atenista-24-bm-vipers-ousts-sea-tigers-in-bid-for-gold-in-mens-bball-slithers-back-to-victory",
+    "image": ""
+  },
+  {
+    "title": "B&M Vipers snatch back gold podium from SON Panthers in bball women",
+    "body": "The Business & Management (B&M) Vipers redeemed their championship title from the School of Nursing (SON) Panthers in the basketball women’s category, edging them out with a score of 36-31 in a fierce rematch against last year’s rivals.",
+    "url": "https://atenews.ph/palarong-atenista-24-bm-vipers-snatch-back-gold-podium-from-son-panthers-in-bball-women",
+    "image": ""
+  },
+  {
+    "title": "B&M Vipers snag top spot in men’s swimming tourney",
+    "body": "The Business and Management (B&M) Vipers surged through the water and took home the gold in the Men’s Singles Swimming Tournament in the Palarong Atenista ‘24.",
+    "url": "https://atenews.ph/palarong-atenista-24-bm-vipers-defend-throne-bags-top-spot-in-mens-swimming-tourney",
+    "image": ""
+  },
+  {
+    "title": "SEA takes lead in swimming women’s singles",
+    "body": "Riding on the momentum of their victory last season, the School of Engineering and Architecture (SEA) Tigers seized another win in the recently concluded Women’s Singles Swimming Tournament in the Palarong Atenista ‘24.",
+    "url": "https://atenews.ph/palarong-atenista-24-sea-takes-lead-in-swimming-womens-singles",
+    "image": ""
+  },
+  {
+    "title": "SEA Tigers claw back to overall champ title with 9 golds",
+    "body": "The School of Engineering and Architecture (SEA) Tigers brought back the overall championship title to their cluster in this year’s Ateneo UFest ‘24 after claiming 9 gold medals and 44 overall accumulated points, leading the sports tally among the other clusters.",
+    "url": "https://atenews.ph/palarong-atenista-24-sea-tigers-claw-back-to-overall-champ-title-with-9-golds",
+    "image": ""
+  }
+]

--- a/src/data/sportsWinnersData.json
+++ b/src/data/sportsWinnersData.json
@@ -1,0 +1,183 @@
+[
+  {
+    "game_title": "Cheerdance Competition",
+    "variant": "normal",
+    "first_place_name": "SON Panthers",
+    "second_place_name": "B&M Vipers",
+    "third_place_name": "ACC Griffins"
+  },
+  {
+    "game_title": "Men's Scrabble Tournament",
+    "variant": "normal",
+    "first_place_name": "SS Dragons",
+    "second_place_name": "ACC Griffins",
+    "third_place_name": "HUMLET Wolves"
+  },
+  {
+    "game_title": "Women's Scrabble Tournament",
+    "variant": "normal",
+    "first_place_name": "ACC Griffins",
+    "second_place_name": "B&M Vipers",
+    "third_place_name": "CS Chameleons"
+  },
+  {
+    "game_title": "Women's Chess Tournament",
+    "variant": "normal",
+    "first_place_name": "ACC Griffins",
+    "second_place_name": "NSM Falcons",
+    "third_place_name": "SEA Tigers"
+  },
+  {
+    "game_title": "Men's Chess Tournament",
+    "variant": "normal",
+    "first_place_name": "SEA Tigers",
+    "second_place_name": "ACC Griffins",
+    "third_place_name": "SS Dragons"
+  },
+  {
+    "game_title": "Men's Badminton",
+    "variant": "split",
+    "split_type": "game type",
+    "var1_first_place_name": "SS Dragons",
+    "var1_second_place_name": "B&M Vipers",
+    "var1_third_place_name": "",
+    "var2_first_place_name": "SEA Tigers",
+    "var2_second_place_name": "ACC Griffins",
+    "var2_third_place_name": ""
+  },
+  {
+    "game_title": "Women's Badminton",
+    "variant": "split",
+    "split_type": "game type",
+    "var1_first_place_name": "SON Panthers",
+    "var1_second_place_name": "SS Dragons",
+    "var1_third_place_name": "ACC Griffins",
+    "var2_first_place_name": "SS Dragons",
+    "var2_second_place_name": "NSM Falcons",
+    "var2_third_place_name": "B&M Vipers"
+  },
+  {
+    "game_title": "Women's Table Tennis",
+    "variant": "split",
+    "split_type": "game type",
+    "var1_first_place_name": "NSM Falcons",
+    "var1_second_place_name": "SS Dragons",
+    "var1_third_place_name": "SON Panthers",
+    "var2_first_place_name": "SS Dragons",
+    "var2_second_place_name": "ACC Griffins",
+    "var2_third_place_name": "NSM Falcons"
+  },
+  {
+    "game_title": "Men's Table Tennis",
+    "variant": "split",
+    "split_type": "game type",
+    "var1_first_place_name": "B&M Vipers",
+    "var1_second_place_name": "SEA Tigers",
+    "var1_third_place_name": "ACC Griffins",
+    "var2_first_place_name": "ACC Griffins",
+    "var2_second_place_name": "SOE Sharks",
+    "var2_third_place_name": "B&M Vipers"
+  },
+  {
+    "game_title": "Women's Darts",
+    "variant": "normal",
+    "first_place_name": "SON Panthers",
+    "second_place_name": "HUMLET Wolves",
+    "third_place_name": ""
+  },
+  {
+    "game_title": "Men's Darts",
+    "variant": "normal",
+    "first_place_name": "SEA Tigers",
+    "second_place_name": "HUMLET Wolves",
+    "third_place_name": "SON Panthers"
+  },
+  {
+    "game_title": "Billiards",
+    "variant": "split",
+    "split_type": "gender",
+    "var1_first_place_name": "SON Panthers",
+    "var1_second_place_name": "SS Dragons",
+    "var1_third_place_name": "B&M Vipers",
+    "var2_first_place_name": "SEA Tigers",
+    "var2_second_place_name": "SON Panthers",
+    "var2_third_place_name": "SOE Sharks"
+  },
+  {
+    "game_title": "Football",
+    "variant": "normal",
+    "first_place_name": "SEA Tigers",
+    "second_place_name": "NSM Falcons",
+    "third_place_name": ""
+  },
+  {
+    "game_title": "Mobile Legends: Bang Bang",
+    "variant": "normal",
+    "first_place_name": "SEA Tigers",
+    "second_place_name": "ACC Griffins",
+    "third_place_name": ""
+  },
+  {
+    "game_title": "DOTA 2",
+    "variant": "normal",
+    "first_place_name": "SEA Tigers",
+    "second_place_name": "CS Chameleons",
+    "third_place_name": ""
+  },
+  {
+    "game_title": "Valorant",
+    "variant": "normal",
+    "first_place_name": "B&M Vipers",
+    "second_place_name": "CS Chameleons",
+    "third_place_name": "SON Panthers"
+  },
+  {
+    "game_title": "Men's Volleyball",
+    "variant": "normal",
+    "first_place_name": "SS Dragons",
+    "second_place_name": "BM Vipers",
+    "third_place_name": "SEA Tigers"
+  },
+  {
+    "game_title": "Women's Volleyball",
+    "variant": "normal",
+    "first_place_name": "SON Panthers",
+    "second_place_name": "HUMLET Wolves",
+    "third_place_name": "SEA Tigers"
+  },
+  {
+    "game_title": "Men's Basketball",
+    "variant": "normal",
+    "first_place_name": "B&M Vipers",
+    "second_place_name": "SEA Tigers",
+    "third_place_name": "SS Dragons"
+  },
+  {
+    "game_title": "Women's Basketball",
+    "variant": "normal",
+    "first_place_name": "B&M Vipers",
+    "second_place_name": "SON Panthers",
+    "third_place_name": ""
+  },
+  {
+    "game_title": "Men's Singles Swimming",
+    "variant": "normal",
+    "first_place_name": "B&M Vipers",
+    "second_place_name": "SS Dragons",
+    "third_place_name": "SON Panthers"
+  },
+  {
+    "game_title": "Women's Singles Swimming",
+    "variant": "normal",
+    "first_place_name": "SEA Tigers",
+    "second_place_name": "SS Dragons",
+    "third_place_name": "SON Panthers"
+  },
+  {
+    "game_title": "Ateneo UFest '24 Overall Championship",
+    "variant": "normal",
+    "first_place_name": "SEA Tigers",
+    "second_place_name": "B&M Vipers",
+    "third_place_name": "SS Dragons"
+  }
+]

--- a/src/utils/transformSportsData.ts
+++ b/src/utils/transformSportsData.ts
@@ -1,0 +1,109 @@
+interface OldSportEvent {
+  game_title: string;
+  variant: string;
+  split_type?: string;
+  first_place_name?: string;
+  second_place_name?: string;
+  third_place_name?: string;
+  var1_first_place_name?: string;
+  var1_second_place_name?: string;
+  var1_third_place_name?: string;
+  var2_first_place_name?: string;
+  var2_second_place_name?: string;
+  var2_third_place_name?: string;
+}
+
+interface ArticleData {
+  title: string;
+  body: string;
+  url: string;
+  image: string;
+}
+
+interface NewSportEvent {
+  game_title: string;
+  variant: string;
+  split_type?: string; // Keep the original strict typing
+  winners: {
+    place: string;
+    name: string;
+  }[];
+  articleTitle: string;
+  articleBody: string;
+  articleUrl: string;
+  articleImage: string;
+}
+
+export function transformSportsData(
+  oldData: OldSportEvent[],
+  articles: ArticleData[]
+): NewSportEvent[] {
+  return oldData.map((event, index) => {
+    const article = articles[index];
+
+    const getWinners = () => {
+      if (event.variant === 'split') {
+        let variant1: string;
+        let variant2: string;
+
+        if (event.split_type === 'gender') {
+          variant1 = "Women's";
+          variant2 = "Men's";
+        } else if (event.split_type === 'game type') {
+          variant1 = 'Doubles';
+          variant2 = 'Singles';
+        } else {
+          variant1 = 'Variant 1';
+          variant2 = 'Variant 2';
+        }
+
+        const splitWinners = [
+          {
+            place: `${variant1} First`,
+            name: event.var1_first_place_name || '',
+          },
+          {
+            place: `${variant1} Second`,
+            name: event.var1_second_place_name || '',
+          },
+          {
+            place: `${variant1} Third`,
+            name: event.var1_third_place_name || '',
+          },
+          {
+            place: `${variant2} First`,
+            name: event.var2_first_place_name || '',
+          },
+          {
+            place: `${variant2} Second`,
+            name: event.var2_second_place_name || '',
+          },
+          {
+            place: `${variant2} Third`,
+            name: event.var2_third_place_name || '',
+          },
+        ];
+
+        return splitWinners.filter((winner) => winner.name !== '');
+      } else {
+        const normalWinners = [
+          { place: 'First', name: event.first_place_name || '' },
+          { place: 'Second', name: event.second_place_name || '' },
+          { place: 'Third', name: event.third_place_name || '' },
+        ];
+        return normalWinners.filter((winner) => winner.name !== '');
+      }
+    };
+
+    return {
+      game_title: event.game_title,
+      variant: event.variant,
+      split_type: event.split_type,
+      winners: getWinners(),
+      articleTitle: article.title,
+      articleBody: article.body,
+      articleUrl: article.url,
+      articleImage: article.image,
+    };
+  });
+}


### PR DESCRIPTION
resolves #15 

# Sports Section Component

## Changes Made
1. Created new `SportsSection` component to display sports articles and tournament winners
2. Added URL prop support for Article and ReadMoreButton components for Atenews website redirection
3. Refactored SportsWinnerContainer for better flexibility:
   - Separated color props for consistent styling with Article component
   - Enhanced support for multiple winner categories (singles/doubles, men's/women's)

## Data Integration
- Created utility function to merge sports articles and winners data
- Maintained separate JSON files for clarity:
  - `sportsArticleData.json`: Article content and metadata
  - `sportsWinnersData.json`: Tournament winners information

## TODO
- Add article images to JSON data (#20 already has the images)
- Mobile responsiveness

## Notes
- Tried to randomize colors, but they should be consistent even on refresh. I added constraints in the scenario where unwanted color combinations occur (same color with title and border, white on green or vice versa), but there might be cases that I did not notice
- Having difficulty with mobile responsiveness, would like some help on this part

## Screenshots
![image](https://github.com/user-attachments/assets/d6dbd639-ba5c-43c0-91cb-10351c368bba)
![image](https://github.com/user-attachments/assets/696df8fa-c488-4eed-8bad-03e2fbfeaa66)

